### PR TITLE
Added flag to set a non-zero exit code

### DIFF
--- a/commands/codechecker/run.cfc
+++ b/commands/codechecker/run.cfc
@@ -42,13 +42,15 @@ component {
 	* @minSeverity.options 1,2,3,4,5
 	* @excelReportPath Path to write Excel report to
 	* @verbose Output full list of files being scanned and all items found to the console
+	* @failOnMatch Sets a non-zero exit code if any matches are found
 	*/
 	function run(
 		string paths,
 		string categories,
 		numeric minSeverity,
 		string excelReportPath,
-		boolean verbose=false
+		boolean verbose=false,
+		boolean failOnMatch=false
 		) {
 
 		try {
@@ -259,6 +261,10 @@ component {
 				print.line();
 			} );
 		}
+
+		if( results.len() && failOnMatch ) {
+			error("", 1);
+		}
 	}
 
 	/**
@@ -353,3 +359,4 @@ component {
 	}
 
 }
+

--- a/commands/codechecker/run.cfc
+++ b/commands/codechecker/run.cfc
@@ -263,7 +263,7 @@ component {
 		}
 
 		if( results.len() && failOnMatch ) {
-			error("", 1);
+			setExitCode( 1 );
 		}
 	}
 


### PR DESCRIPTION
Adds `--failOnMatch` so a non-zero exit code can be set. See #5 for further discussion.